### PR TITLE
Add MIT license, correct copyright

### DIFF
--- a/point-stack.el
+++ b/point-stack.el
@@ -1,7 +1,31 @@
 ;;; point-stack.el --- Back and forward navigation through buffer locations
 
-;; Author: Dmitry Gutov <dgutov@yandex.ru>
+;; Copyright (c) 2010 Matt Harrison
+;; Copyright (c) 2011-2014 Dmitry Gutov
+
+;; Author: Matt Harrison <matthewharrison@gmail.com>
+;;         Dmitry Gutov <dgutov@yandex.ru>
 ;; Version: 1.1
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
 
 ;;; Commentary:
 


### PR DESCRIPTION
The original author has chosen this license, see
https://github.com/dgutov/point-stack/issues/2
I am only putting it into the file.